### PR TITLE
Fix vorpal plate bug referenced by Issue #13

### DIFF
--- a/FIXES
+++ b/FIXES
@@ -63,3 +63,5 @@
   will now be drained as expected when poisoned.
 
 - Fixed the drop rate for Harmonic Gems
+
+- Fix vorpal plating damage calculation

--- a/battle/char/executeMeleeAttack.asm
+++ b/battle/char/executeMeleeAttack.asm
@@ -297,10 +297,12 @@ l_addVorpalPlateBonus:
 	sub	ah, ah
 	cmp	ax, [bp+vorpalLoopCounter]
 	jbe	short l_calculateDamageNext
+
 	CALL(random)
-	and	ax, 4				; This is a bug. It's supposed to be a number
-	add	gs:damageAmount, ax		; between 1 and 4. (x AND 4) returns either 0
-	inc	[bp+vorpalLoopCounter]			; or 4.
+	and	ax, 3					; AND ax with 3 to get 0-3
+	inc	ax					; increment result to get 1-4
+	add	gs:damageAmount, ax
+	inc	[bp+vorpalLoopCounter]
 	jmp	short l_addVorpalPlateBonus
 
 l_calculateDamageNext:


### PR DESCRIPTION
Replace `and ax,4` with
```
  and ax, 3
  inc ax
```
to get a result of `1-4`